### PR TITLE
Stab in the dark at fixing memory bloat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "onesignal-tracing-tail-sample"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2018"
 license = "MIT"
 repository = "https://github.com/OneSignal/tracing-tail-sampling/"

--- a/src/opentelemetry/layer.rs
+++ b/src/opentelemetry/layer.rs
@@ -55,13 +55,15 @@ impl TraceCache {
     where
         T: otel::Tracer + PreSampledTracer + 'static,
     {
-        while let Some(span) = self.spans.pop_front() {
+        let trace_spans = std::mem::replace(&mut self.spans, Default::default());
+
+        for span in trace_spans {
             span.start(tracer);
         }
     }
 
     fn clear(&mut self) {
-        self.spans.clear();
+        drop(std::mem::replace(&mut self.spans, Default::default()));
     }
 }
 


### PR DESCRIPTION
It's been a while since I've looked deeply at this, but IIRC, tracing
keeps a cache of spans around, and thus the extensions may also be kept
around, which means the TraceCache may even be kept around. If that's
the case, the list of spans would grow on all of them until it reaches a
maximum value which could be quite a lot of memory. To avoid that, the
allocation is freed both when a trace is sent and in the reset.

note that if this is being kept around, we might need to reset the
`SampleDecision` extension as well.