### PR TITLE
Add support for opentelemetry 0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "onesignal-tracing-tail-sample"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2018"
 license = "MIT"
 repository = "https://github.com/OneSignal/tracing-tail-sampling/"
@@ -13,7 +13,7 @@ description = "Tail sampling support for tracing with OpenTelemetry"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-core = { version = "0.1" }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
-opentelemetry = { version = "0.18", default-features = false, features = ["trace"] }
+opentelemetry = { version = ">=0.18, <0.20", default-features = false, features = ["trace"] }
 uuid = { version = "0.8", features = ["v4"] }
 
 [dev-dependencies]


### PR DESCRIPTION
No code changes were needed for this so we can support this alongside 0.18 without making a breaking change.