### PR TITLE
Loosen `uuid` crate version requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "onesignal-tracing-tail-sample"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2018"
 license = "MIT"
 repository = "https://github.com/OneSignal/tracing-tail-sampling/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-core = { version = "0.1" }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
 opentelemetry = { version = ">=0.18, <0.20", default-features = false, features = ["trace"] }
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = ">= 0.8, < 2", features = ["v4"] }
 
 [dev-dependencies]
 async-trait = "0.1"


### PR DESCRIPTION
It doesn't seem like this *needs* 0.8. Let's loosen the version requirement so that upstream libraries/applications that want to use `uuid` 1.x don't need to compile two versions of `uuid`.