### PR TITLE
Upgrade `opentelemetry` and friends

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "onesignal-tracing-tail-sample"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2018"
 license = "MIT"
 repository = "https://github.com/OneSignal/tracing-tail-sampling/"
@@ -12,11 +12,16 @@ description = "Tail sampling support for tracing with OpenTelemetry"
 [dependencies]
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-core = { version = "0.1" }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
-opentelemetry = { version = ">=0.18, <0.20", default-features = false, features = ["trace"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = [
+    "registry",
+    "std",
+] }
+opentelemetry = { version = ">=0.23", default-features = false }
+opentelemetry_sdk = { version = ">=0.23" }
 uuid = { version = ">= 0.8, < 2", features = ["v4"] }
 
 [dev-dependencies]
 async-trait = "0.1"
 criterion = { version = "0.3", default_features = false }
-opentelemetry-jaeger = { version = ">=0.17, <0.19" }
+opentelemetry-jaeger = { version = ">=0.22" }
+opentelemetry-stdout = { version = ">=0.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,14 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
     "registry",
     "std",
 ] }
-opentelemetry = { version = ">=0.23", default-features = false }
-opentelemetry_sdk = { version = ">=0.23" }
+
+opentelemetry = { version = "0.23", default-features = false }
+opentelemetry_sdk = { version = "0.23" }
+
 uuid = { version = ">= 0.8, < 2", features = ["v4"] }
 
 [dev-dependencies]
 async-trait = "0.1"
 criterion = { version = "0.3", default_features = false }
-opentelemetry-jaeger = { version = ">=0.22" }
-opentelemetry-stdout = { version = ">=0.4" }
+opentelemetry-jaeger = { version = "0.22" }
+opentelemetry-stdout = { version = "0.4" }

--- a/src/opentelemetry/layer.rs
+++ b/src/opentelemetry/layer.rs
@@ -247,7 +247,7 @@ impl<'a> SpanAttributeVisitor<'a> {
     fn record(&mut self, attribute: KeyValue) {
         debug_assert!(self.0.attributes.is_some());
         if let Some(v) = self.0.attributes.as_mut() {
-            v.push(KeyValue::new(attribute.key, attribute.value));
+            v.push(attribute);
         }
     }
 }

--- a/src/opentelemetry/layer.rs
+++ b/src/opentelemetry/layer.rs
@@ -247,7 +247,7 @@ impl<'a> SpanAttributeVisitor<'a> {
     fn record(&mut self, attribute: KeyValue) {
         debug_assert!(self.0.attributes.is_some());
         if let Some(v) = self.0.attributes.as_mut() {
-            v.insert(attribute.key, attribute.value);
+            v.push(KeyValue::new(attribute.key, attribute.value));
         }
     }
 }
@@ -505,22 +505,29 @@ where
             builder.trace_id = Some(self.tracer.new_trace_id());
         }
 
-        let builder_attrs = builder
-            .attributes
-            .get_or_insert(opentelemetry::trace::OrderMap::new());
+        let builder_attrs = builder.attributes.get_or_insert(vec![]);
 
         let meta = attrs.metadata();
 
         if let Some(filename) = meta.file() {
-            builder_attrs.insert("code.filepath".into(), filename.into());
+            builder_attrs.push(KeyValue::new(
+                Key::new("code.filepath"),
+                Value::from(filename),
+            ));
         }
 
         if let Some(module) = meta.module_path() {
-            builder_attrs.insert("code.namespace".into(), module.into());
+            builder_attrs.push(KeyValue::new(
+                Key::new("code.namespace"),
+                Value::from(module),
+            ));
         }
 
         if let Some(line) = meta.line() {
-            builder_attrs.insert("code.lineno".into(), (line as i64).into());
+            builder_attrs.push(KeyValue::new(
+                Key::new("code.lineno"),
+                Value::from(line as i64),
+            ));
         }
 
         attrs.record(&mut SpanAttributeVisitor(&mut builder));
@@ -589,7 +596,7 @@ where
             .span()
             .span_context()
             .clone();
-        let follows_link = otel::Link::new(follows_context, Vec::new());
+        let follows_link = otel::Link::new(follows_context, Vec::new(), 0);
         if let Some(ref mut links) = data.builder.links {
             links.push(follows_link);
         } else {
@@ -667,8 +674,8 @@ where
                     let idle_ns = KeyValue::new("idle_ns", timings.idle);
 
                     let attributes = builder.attributes.get_or_insert_with(|| Default::default());
-                    attributes.insert(busy_ns.key, busy_ns.value);
-                    attributes.insert(idle_ns.key, idle_ns.value);
+                    attributes.push(KeyValue::new(busy_ns.key, busy_ns.value));
+                    attributes.push(KeyValue::new(idle_ns.key, idle_ns.value));
                 }
             }
 
@@ -758,7 +765,7 @@ mod tests {
         where
             T: Into<Cow<'static, str>>,
         {
-            noop::NoopSpan::new()
+            noop::NoopSpan::DEFAULT
         }
         fn span_builder<T>(&self, name: T) -> otel::SpanBuilder
         where
@@ -775,7 +782,7 @@ mod tests {
                 builder,
                 parent_cx: parent_cx.clone(),
             });
-            noop::NoopSpan::new()
+            noop::NoopSpan::DEFAULT
         }
     }
 
@@ -801,6 +808,7 @@ mod tests {
             _: Vec<KeyValue>,
         ) {
         }
+        fn add_link(&mut self, _span_context: otel::SpanContext, _attributes: Vec<KeyValue>) {}
 
         fn span_context(&self) -> &otel::SpanContext {
             &self.0
@@ -881,10 +889,10 @@ mod tests {
     fn trace_id_from_existing_context() {
         let tracer = TestTracer(Arc::new(Mutex::new(None)));
         let subscriber = tracing_subscriber::registry().with(layer().with_tracer(tracer.clone()));
-        let trace_id = otel::TraceId::from(42u128.to_be_bytes());
+        let trace_id = otel::TraceId::from(42u128);
         let existing_cx = OtelContext::current_with_span(TestSpan(otel::SpanContext::new(
             trace_id,
-            otel::SpanId::from(1u64.to_be_bytes()),
+            otel::SpanId::from(1u64),
             TraceFlags::default(),
             false,
             Default::default(),
@@ -934,7 +942,7 @@ mod tests {
             .clone();
         let keys = attributes
             .iter()
-            .map(|(key, _)| key.as_str())
+            .map(|kv| kv.key.as_str())
             .collect::<Vec<&str>>();
         assert!(keys.contains(&"idle_ns"));
         assert!(keys.contains(&"busy_ns"));
@@ -1000,7 +1008,7 @@ mod tests {
 
         let key_values = attributes
             .into_iter()
-            .map(|(key, value)| (key.as_str().to_owned(), value))
+            .map(|kv| (kv.key.as_str().to_owned(), kv.value))
             .collect::<HashMap<_, _>>();
 
         assert_eq!(key_values["error"].as_str(), "user error");

--- a/src/opentelemetry/mod.rs
+++ b/src/opentelemetry/mod.rs
@@ -79,13 +79,18 @@
 //! ## Examples
 //!
 //! ```
-//! use opentelemetry::sdk::export::trace::stdout;
+//! use opentelemetry::trace::TracerProvider as _;
+//! use opentelemetry_sdk::trace::TracerProvider;
+//! use opentelemetry_stdout::SpanExporter;
 //! use tracing::{error, span};
 //! use tracing_subscriber::layer::SubscriberExt;
 //! use tracing_subscriber::Registry;
 //!
-//! // Create a new OpenTelemetry pipeline
-//! let tracer = stdout::new_pipeline().install_simple();
+//! // Create a new OpenTelemetry tracer
+//! let provider = TracerProvider::builder()
+//!    .with_simple_exporter(SpanExporter::default())
+//!    .build();
+//! let tracer = provider.tracer("test-tracer");
 //!
 //! // Create a tracing layer with the configured tracer
 //! let telemetry = onesignal_tracing_tail_sample::opentelemetry::layer().with_tracer(tracer);

--- a/src/opentelemetry/span_ext.rs
+++ b/src/opentelemetry/span_ext.rs
@@ -44,7 +44,7 @@ pub trait OpenTelemetrySpanExt {
     ///
     /// ```rust
     /// use opentelemetry::{propagation::TextMapPropagator, trace::TraceContextExt};
-    /// use opentelemetry::sdk::propagation::TraceContextPropagator;
+    /// use opentelemetry_sdk::propagation::TraceContextPropagator;
     /// use onesignal_tracing_tail_sample::opentelemetry::OpenTelemetrySpanExt;
     /// use std::collections::HashMap;
     /// use tracing::Span;
@@ -78,7 +78,7 @@ pub trait OpenTelemetrySpanExt {
     ///
     /// ```rust
     /// use opentelemetry::{propagation::TextMapPropagator, trace::TraceContextExt};
-    /// use opentelemetry::sdk::propagation::TraceContextPropagator;
+    /// use opentelemetry_sdk::propagation::TraceContextPropagator;
     /// use onesignal_tracing_tail_sample::opentelemetry::OpenTelemetrySpanExt;
     /// use std::collections::HashMap;
     /// use tracing::Span;
@@ -170,7 +170,7 @@ impl OpenTelemetrySpanExt for tracing::Span {
                     get_context.with_context(subscriber, id, move |data, _tracer| {
                         if let Some(cx) = cx.take() {
                             let attr = att.take().unwrap_or_default();
-                            let follows_link = opentelemetry::trace::Link::new(cx, attr);
+                            let follows_link = opentelemetry::trace::Link::new(cx, attr, 0);
                             data.builder
                                 .links
                                 .get_or_insert_with(|| Vec::with_capacity(1))


### PR DESCRIPTION
Upgrades `opentelemetry` to help consolidate redundant crate versions [downstream](https://app.asana.com/0/0/1207760336549309/1207770799372356/f).

There were a few breaking changes, and I've likely diverged some from `tracing-opentelemetry`'s current implementation. The surface area wasn't huge though, so seemed ok to apply patches here and there instead of re-forking the crate and starting over. 

If anyone feels strongly about straying too far from the source, I can close the PR and re-approach another time.