### PR TITLE
Bump `opentelemetry` to 0.24.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ save_cache: &save_cache
 jobs:
   lint_and_test:
     docker:
-      - image: europe-west4-docker.pkg.dev/core-infra-onesignal/development/rust-ubuntu:1.73.0-r1
+      - image: europe-west4-docker.pkg.dev/core-infra-onesignal/development/rust-ubuntu:1.78.0-r1
         auth:
           username: $DOCKER_LOGIN
           password: $DOCKER_PASSWORD
@@ -27,7 +27,7 @@ jobs:
 
   build_and_save:
     docker:
-      - image: europe-west4-docker.pkg.dev/core-infra-onesignal/development/rust-ubuntu:1.73.0-r1
+      - image: europe-west4-docker.pkg.dev/core-infra-onesignal/development/rust-ubuntu:1.78.0-r1
         auth:
           username: $DOCKER_LOGIN
           password: $DOCKER_PASSWORD
@@ -39,7 +39,7 @@ jobs:
 
   cloudsmith-deploy:
     docker:
-      - image: europe-west4-docker.pkg.dev/core-infra-onesignal/development/rust-ubuntu:1.73.0-r1
+      - image: europe-west4-docker.pkg.dev/core-infra-onesignal/development/rust-ubuntu:1.78.0-r1
         auth:
           username: $DOCKER_LOGIN
           password: $DOCKER_PASSWORD

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ description = "Tail sampling support for tracing with OpenTelemetry"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+# For those using cargo-udeps, ignore dev-dependencies that are only used in doctests.
+[package.metadata.cargo-udeps.ignore]
+development = ["opentelemetry-otlp", "opentelemetry-stdout"]
+
 [dependencies]
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-core = { version = "0.1" }
@@ -23,7 +27,5 @@ opentelemetry_sdk = { version = "0.24" }
 uuid = { version = ">= 0.8, < 2", features = ["v4"] }
 
 [dev-dependencies]
-async-trait = "0.1"
-criterion = { version = ">= 0.3, <= 0.5.1", default_features = false }
 opentelemetry-otlp = { version = "0.17", features = ["metrics"] }
 opentelemetry-stdout = { version = "0.5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "onesignal-tracing-tail-sample"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2018"
 license = "MIT"
 repository = "https://github.com/OneSignal/tracing-tail-sampling/"
@@ -17,13 +17,13 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
     "std",
 ] }
 
-opentelemetry = { version = "0.23", default-features = false }
-opentelemetry_sdk = { version = "0.23" }
+opentelemetry = { version = "0.24", default-features = false }
+opentelemetry_sdk = { version = "0.24" }
 
 uuid = { version = ">= 0.8, < 2", features = ["v4"] }
 
 [dev-dependencies]
 async-trait = "0.1"
-criterion = { version = "0.3", default_features = false }
-opentelemetry-jaeger = { version = "0.22" }
-opentelemetry-stdout = { version = "0.4" }
+criterion = { version = ">= 0.3, <= 0.5.1", default_features = false }
+opentelemetry-otlp = { version = "0.17", features = ["metrics"] }
+opentelemetry-stdout = { version = "0.5" }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.2"
 services:
   code:
-    image: europe-west4-docker.pkg.dev/core-infra-onesignal/development/rust-ubuntu:1.73.0-r1
+    image: europe-west4-docker.pkg.dev/core-infra-onesignal/development/rust-ubuntu:1.78.0-r1
     stdin_open: true
     tty: true
     working_dir: /code

--- a/src/opentelemetry/layer.rs
+++ b/src/opentelemetry/layer.rs
@@ -348,13 +348,18 @@ where
     /// ```no_run
     /// use onesignal_tracing_tail_sample::opentelemetry::OpenTelemetryLayer;
     /// use tracing_subscriber::layer::SubscriberExt;
+    /// use opentelemetry::trace::TracerProvider;
     /// use tracing_subscriber::Registry;
     ///
-    /// // Create a jaeger exporter pipeline for a `trace_demo` service.
-    /// let tracer = opentelemetry_jaeger::new_agent_pipeline()
-    ///     .with_service_name("trace_demo")
+    /// // Create an OTLP pipeline exporter for a `trace_demo` service.
+    ///
+    /// let otlp_exporter = opentelemetry_otlp::new_exporter().tonic();
+    /// let tracer = opentelemetry_otlp::new_pipeline()
+    ///     .tracing()
+    ///     .with_exporter(otlp_exporter)
     ///     .install_simple()
-    ///     .expect("Error initializing Jaeger exporter");
+    ///     .unwrap()
+    ///     .tracer("trace_demo");
     ///
     /// // Create a layer with the configured tracer
     /// let otel_layer = OpenTelemetryLayer::new(tracer);
@@ -384,12 +389,17 @@ where
     /// ```no_run
     /// use tracing_subscriber::layer::SubscriberExt;
     /// use tracing_subscriber::Registry;
+    /// use opentelemetry::trace::TracerProvider;
     ///
-    /// // Create a jaeger exporter pipeline for a `trace_demo` service.
-    /// let tracer = opentelemetry_jaeger::new_agent_pipeline()
-    ///     .with_service_name("trace_demo")
+    /// // Create an OTLP pipeline exporter for a `trace_demo` service.
+    ///
+    /// let otlp_exporter = opentelemetry_otlp::new_exporter().tonic();
+    /// let tracer = opentelemetry_otlp::new_pipeline()
+    ///     .tracing()
+    ///     .with_exporter(otlp_exporter)
     ///     .install_simple()
-    ///     .expect("Error initializing Jaeger exporter");
+    ///     .unwrap()
+    ///     .tracer("trace_demo");
     ///
     /// // Create a layer with the configured tracer
     /// let otel_layer = onesignal_tracing_tail_sample::opentelemetry::layer().with_tracer(tracer);


### PR DESCRIPTION
Asana ticket [here](https://app.asana.com/0/1207601841822249/1207760336549309/1207899184295582/f).

https://github.com/OneSignal/tracing-tail-sampling/pull/11 improved things, but there were a couple of lingering duplicate crate versions in dependent onesignal lockfiles. This _should_ be the rest of what we need to dedupe versions of axum, http, tonic, etc.

The maintainers of `opentelemetry` and `tracing-opentelemetry` have worked out the issues @cstyles described in https://github.com/OneSignal/logging-base/pull/28 , so we're unblocked now. I essentially just followed [what they did in tracing-opentelemetry](https://github.com/tokio-rs/tracing-opentelemetry/commit/83adbfff70ba72074f4d9ab852f8f926e2820fb8#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542) to make the same upgrades, i.e.use a [new id_generator() method](https://github.com/open-telemetry/opentelemetry-rust/pull/1934) in place of the removed/privatized `provider()`.